### PR TITLE
Increase GEM_TEMP_OBJECT_CACHE_SIZE

### DIFF
--- a/start-gemstone.sh
+++ b/start-gemstone.sh
@@ -14,6 +14,10 @@ printTestingErrorAndExit(){
   exit 1
 }
 
+echo "::group::Configuring GemStone services"
+echo "GEM_TEMPOBJ_CACHE_SIZE = 500000KB;" >> "${GEMSTONE_SYS_CONF}/system.conf"
+echo "::endgroup::"
+
 echo "::group::Starting GemStone services"
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
To avoid errors like:
```
GemStone: Error         Fatal
  VM temporary object memory is full 
  , almost out of memory, too many markSweeps since last successful scavenge
  Error Category: 231169 [GemStone] Number: 4067  Arg Count: 1 Context : 20 exception : 20
  Arg 1: nil
  topaz > exec iferr 1 : exit 1 
```
when loading code