### PR TITLE
Update docker images to use the non-root version of the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM ghcr.io/ba-st/gs64-rowan:v3.7.0
+FROM ghcr.io/ba-st/gs64-rowan:non_root_image
 
-COPY start-gemstone.sh /opt/gemstone/start-gemstone.sh
+COPY stone-ci.sh /opt/gemstone/stone-ci.sh
 
+USER root
 RUN  apt-get update \
   && apt-get install --assume-yes --no-install-recommends \
      libcap2-bin \
@@ -13,4 +14,6 @@ RUN  apt-get update \
   && setcap -r $GEMSTONE/sys/pgsvrmain \
   ;
 
-ENTRYPOINT [ "/opt/gemstone/entrypoint.sh" ]
+USER ${GS_USER}
+
+ENTRYPOINT [ "/opt/gemstone/stone-ci.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ba-st/gs64-rowan:non_root_image
+FROM ghcr.io/ba-st/gs64-rowan:v3.7.0
 
 COPY stone-ci.sh /opt/gemstone/stone-ci.sh
 

--- a/stone-ci.sh
+++ b/stone-ci.sh
@@ -15,6 +15,15 @@ printTestingErrorAndExit(){
 }
 
 echo "::group::Configuring GemStone services"
+# Copy default system config if missing
+if [ ! -f "${GEMSTONE_SYS_CONF}/system.conf" ]; then
+  cp -p "${GEMSTONE}/data/system.conf" "${GEMSTONE_SYS_CONF}/system.conf"
+fi
+
+# Create (empty) stone config if missing
+if [ ! -f "${GEMSTONE_EXE_CONF}/${STONE_SERVICE_NAME}.conf" ]; then
+  touch "${GEMSTONE_EXE_CONF}/${STONE_SERVICE_NAME}.conf"
+fi
 echo "GEM_TEMPOBJ_CACHE_SIZE = 500000KB;" >> "${GEMSTONE_SYS_CONF}/system.conf"
 # Workaroung for bug in the native code generator for GS 3.7.0
 echo "GEM_NATIVE_CODE_ENABLED = 0;" >> "${GEMSTONE_SYS_CONF}/system.conf"


### PR DESCRIPTION
These changes requires ba-st/Docker-GemStone-64#14 to be merged and released as a new version